### PR TITLE
rustup: fix computing of the file download URI

### DIFF
--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -350,7 +350,6 @@ pub fn sync_rustup_init(
 /// Get the rustup file downloads, in pairs of URLs and sha256 hashes.
 pub fn rustup_download_list(
     path: &Path,
-    source: &str,
     platforms: &Platforms,
 ) -> Result<(String, Vec<(String, String)>), SyncError> {
     let channel_str = fs::read_to_string(path).map_err(DownloadError::Io)?;
@@ -375,7 +374,7 @@ pub fn rustup_download_list(
                             .flatten()
                             .map(|(url, hash)| {
                                 (
-                                    url[source.len()..].trim_start_matches('/').to_string(),
+                                    url.split("/").collect::<Vec<&str>>()[3..].join("/"),
                                     hash,
                                 )
                             })
@@ -573,7 +572,7 @@ pub fn sync_rustup_channel(
     download_with_sha256_file(&channel_url, &channel_part_path, retries, true, user_agent)?;
 
     // Open toml file, find all files to download
-    let (date, files) = rustup_download_list(&channel_part_path, source, &platforms)?;
+    let (date, files) = rustup_download_list(&channel_part_path, &platforms)?;
 
     // Create progress bar
     let (pb_thread, sender) = progress_bar(Some(files.len()), prefix);


### PR DESCRIPTION
If the `source` length didn't perfectly match the length of the default
source (https://static.rust-lang.org), the computed URI would be wrong.
e.g:
original URL:
https://static.rust-lang.org/dist/2021-03-25/rustc-1.51.0-x86_64-unknown-linux-gnu.tar.gz
with `source = "https://short.org"`:
https://short.orgst-lang.org/dist/2021-03-25/rustc-1.51.0-x86_64-unknown-linux-gnu.tar.gz
with `source = "https://a.very.long.mirror.url.rust.mirror.org"`:
https://a.very.long.mirror.url.rust.mirror.orgustc-1.51.0-x86_64-unknown-linux-gnu.tar.gz

This commit provides a better heuristic to get the URI, in the lack of
proper URL parsing.