### PR TITLE
Use origin/master instead of FETCH_HEAD

### DIFF
--- a/src/crates_index.rs
+++ b/src/crates_index.rs
@@ -94,7 +94,7 @@ pub fn update_crates_config(
 fn fast_forward(repo_path: &Path) -> Result<(), IndexSyncError> {
     let repo = Repository::open(repo_path)?;
 
-    let fetch_head = repo.find_reference("FETCH_HEAD")?;
+    let fetch_head = repo.find_reference("refs/remotes/origin/master")?;
     let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
 
     // Force fast-forward on master


### PR DESCRIPTION
Use `refs/remotes/origin/master` instead of FETCH_HEAD. I've learned that FETCH_HEAD is a short-lived reference and, from what I can tell, has caused issues for many people programmatically using it. This origin/master reference should be much more reliable.

I've also found a related issue where crates don't get sync'd on the first run (because origin/master and master are identical), so I've added a check for this to make sure everything is grabbed when these match.

Fixes #24.