### PR TITLE
Add dev feature flag that only downloads z crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,10 @@ glob = "0.3.0"
 git2 = "0.13.18"
 serde_json = "1.0.64"
 thiserror = "1.0.24"
+
+[features]
+default = []
+
+# For development purposes, reduce the crate download count
+# and only download crates that start with z
+dev_reduced_crates = []

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -81,7 +81,6 @@ pub fn sync_crates_files(
     crates: &ConfigCrates,
     user_agent: &HeaderValue,
 ) -> Result<(), SyncError> {
-
     let prefix = if cfg!(feature = "dev_reduced_crates") {
         format!("{} Syncing 'z' crates files... ", style("[2/3]").bold())
     } else {
@@ -126,12 +125,17 @@ pub fn sync_crates_files(
                 // Skip config.json, as it's the only file that's not a crate descriptor
                 return true;
             }
-            
+
             // DEV: if dev_reduced_crates is enabled, only download crates that start with z
             #[cfg(feature = "dev_reduced_crates")]
             {
                 // Get file name, try-convert to string, check if starts_with z, unwrap, or false if None
-                if !p.file_name().and_then(|x| x.to_str()).map(|x| x.starts_with("z")).unwrap_or(false) {
+                if !p
+                    .file_name()
+                    .and_then(|x| x.to_str())
+                    .map(|x| x.starts_with("z"))
+                    .unwrap_or(false)
+                {
                     return true;
                 }
             }
@@ -169,7 +173,12 @@ pub fn sync_crates_files(
                 #[cfg(feature = "dev_reduced_crates")]
                 {
                     // Get file name, try-convert to string, check if starts_with z, unwrap, or false if None
-                    if !p.file_name().and_then(|x| x.to_str()).map(|x| x.starts_with("z")).unwrap_or(false) {
+                    if !p
+                        .file_name()
+                        .and_then(|x| x.to_str())
+                        .map(|x| x.starts_with("z"))
+                        .unwrap_or(false)
+                    {
                         return true;
                     }
                 }

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -133,7 +133,7 @@ pub fn sync_crates_files(
                 if !p
                     .file_name()
                     .and_then(|x| x.to_str())
-                    .map(|x| x.starts_with("z"))
+                    .map(|x| x.starts_with('z'))
                     .unwrap_or(false)
                 {
                     return true;
@@ -176,7 +176,7 @@ pub fn sync_crates_files(
                     if !p
                         .file_name()
                         .and_then(|x| x.to_str())
-                        .map(|x| x.starts_with("z"))
+                        .map(|x| x.starts_with('z'))
                         .unwrap_or(false)
                     {
                         return true;


### PR DESCRIPTION
For development purposes only, this feature crate will ignore all crates that don't start with z. It will continue to grab the full crates.io-index repo, however the crates directory will only be populated with z-crates.

At the time of making this PR, there are only about 400 z-crates, and about 2000 versions amongst those z-crates.

To use this flag, either do:

```
cargo run --features dev_reduced_crates -- sync ~/rust_mirror_dir/
```

or

```
cargo install --path . --features dev_reduced_crates
panamax sync ~/rust_mirror_dir
```