### PR TITLE
Add support for pinning rust versions

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -1,7 +1,6 @@
 use crate::download::{download, DownloadError};
 use crate::mirror::{ConfigCrates, ConfigMirror};
-use crate::progress_bar::{progress_bar, ProgressBarMessage};
-use console::style;
+use crate::progress_bar::{padded_prefix_message, progress_bar, ProgressBarMessage};
 use git2::Repository;
 use reqwest::header::HeaderValue;
 use scoped_threadpool::Pool;
@@ -82,9 +81,9 @@ pub fn sync_crates_files(
     user_agent: &HeaderValue,
 ) -> Result<(), SyncError> {
     let prefix = if cfg!(feature = "dev_reduced_crates") {
-        format!("{} Syncing 'z' crates files... ", style("[2/3]").bold())
+        padded_prefix_message(2, 3, "Syncing 'z' crates files")
     } else {
-        format!("{} Syncing crates files...     ", style("[2/3]").bold())
+        padded_prefix_message(2, 3, "Syncing crates files")
     };
 
     // For now, assume successful crates.io-index download

--- a/src/crates_index.rs
+++ b/src/crates_index.rs
@@ -1,7 +1,6 @@
 use serde::Serialize;
 use std::{io, num::TryFromIntError, path::Path};
 
-use console::style;
 use git2::{
     build::{CheckoutBuilder, RepoBuilder},
     FetchOptions, RemoteCallbacks, Repository, Signature,
@@ -9,7 +8,7 @@ use git2::{
 use thiserror::Error;
 
 use crate::mirror::ConfigCrates;
-use crate::progress_bar::{progress_bar, ProgressBarMessage};
+use crate::progress_bar::{padded_prefix_message, progress_bar, ProgressBarMessage};
 
 #[derive(Error, Debug)]
 pub enum IndexSyncError {
@@ -38,7 +37,7 @@ pub fn sync_crates_repo(mirror_path: &Path, crates: &ConfigCrates) -> Result<(),
     let repo_path = mirror_path.join("crates.io-index");
 
     // Set up progress bar piping.
-    let prefix = format!("{} Fetching crates.io-index... ", style("[1/3]").bold());
+    let prefix = padded_prefix_message(1, 3, "Fetching crates.io-index");
     let (pb_thread, sender) = progress_bar(None, prefix);
 
     // Libgit2 has callbacks that allow us to update the progress bar
@@ -138,7 +137,10 @@ pub fn rewrite_config_json(repo_path: &Path, base_url: &str) -> Result<(), Index
     let refname = "refs/heads/master";
     let signature = Signature::now("Panamax", "panamax@panamax")?;
 
-    eprintln!("{} Syncing index and config... ", style("[3/3]").bold());
+    eprintln!(
+        "{}",
+        padded_prefix_message(3, 3, "Syncing index and config")
+    );
 
     // Set master to origin/master.
     fast_forward(&repo_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,5 +51,5 @@ fn main() {
         Panamax::Sync { path } => mirror::sync(&path),
         Panamax::Rewrite { path, base_url } => mirror::rewrite(&path, base_url),
     }
-    .unwrap();
+    .unwrap_or_else(|e| eprintln!("Panamax command failed! {}", e));
 }

--- a/src/mirror.default.toml
+++ b/src/mirror.default.toml
@@ -41,6 +41,19 @@ keep_latest_stables = 1
 keep_latest_betas = 1
 keep_latest_nightlies = 1
 
+# Pinned versions of Rust to download and keep alongside latest stable/beta/nightly
+# Version specifiers should be in the rustup toolchain format:
+#
+# <channel>[-<date>][-<host>]
+#
+# <channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
+# <date>          = YYYY-MM-DD
+# <host>          = <target-triple>
+#
+# e.g. valid versions could be "1.42", "1.42.0", and "nightly-2014-12-18"
+pinned_rust_versions = [
+]
+
 # The platforms to include in the mirror
 # These lists can be empty to mirror nothing, but if the setting is not set, it will default to all platforms.
 # Note: These platforms should match the list on https://rust-lang.github.io/rustup/installation/other.html

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -34,6 +34,7 @@ pub struct ConfigRustup {
     pub keep_latest_stables: Option<usize>,
     pub keep_latest_betas: Option<usize>,
     pub keep_latest_nightlies: Option<usize>,
+    pub pinned_rust_versions: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -1,3 +1,4 @@
+use console::{pad_str, style};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::sync::mpsc;
 use std::sync::mpsc::Sender;
@@ -55,4 +56,18 @@ pub fn progress_bar(
     });
 
     (pb_thread, sender)
+}
+
+pub fn current_step_prefix(step: usize, steps: usize) -> String {
+    style(format!("[{}/{}]", step, steps)).bold().to_string()
+}
+
+pub fn padded_prefix_message(step: usize, steps: usize, msg: &str) -> String {
+    pad_str(
+        &format!("{} {}...", current_step_prefix(step, steps), msg),
+        34,
+        console::Alignment::Left,
+        None,
+    )
+    .to_string()
 }


### PR DESCRIPTION
Adds support to panamax to allow pinning rust versions to download alongside stable/beta/nightly.