### PR TITLE
Add option to skip downloading rustc-dev

### DIFF
--- a/src/mirror.default.toml
+++ b/src/mirror.default.toml
@@ -54,6 +54,9 @@ keep_latest_nightlies = 1
 pinned_rust_versions = [
 ]
 
+# Whether to download the rustc-dev component
+download_dev = false
+
 # The platforms to include in the mirror
 # These lists can be empty to mirror nothing, but if the setting is not set, it will default to all platforms.
 # Note: These platforms should match the list on https://rust-lang.github.io/rustup/installation/other.html

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -29,6 +29,7 @@ pub struct ConfigRustup {
     pub sync: bool,
     pub download_threads: usize,
     pub source: String,
+    pub download_dev: Option<bool>,
     pub platforms_unix: Option<Vec<String>>,
     pub platforms_windows: Option<Vec<String>>,
     pub keep_latest_stables: Option<usize>,


### PR DESCRIPTION
Default to false as rustc-dev is not normally necessary, and greatly
increases the download size.