### PR TITLE
Remove the need for rewriting URLs 

### DIFF
--- a/src/crates_index.rs
+++ b/src/crates_index.rs
@@ -154,7 +154,10 @@ pub fn rewrite_config_json(repo_path: &Path, base_url: &str) -> Result<(), Index
 
     let mut index = repo.index()?;
 
-    let crate_path = format!("{}/{}", base_url, "{prefix}/{crate}-{version}.crate");
+    let crate_path = format!(
+        "{}/{}",
+        base_url, "{prefix}/{crate}/{version}/{crate}-{version}.crate"
+    );
 
     // Create the new config.json.
     let config_json = ConfigJson {

--- a/src/crates_index.rs
+++ b/src/crates_index.rs
@@ -154,7 +154,7 @@ pub fn rewrite_config_json(repo_path: &Path, base_url: &str) -> Result<(), Index
 
     let mut index = repo.index()?;
 
-    let crate_path = format!("{}/{}", base_url, "{crate}/{crate}-{version}.crate");
+    let crate_path = format!("{}/{}", base_url, "{prefix}/{crate}-{version}.crate");
 
     // Create the new config.json.
     let config_json = ConfigJson {


### PR DESCRIPTION
As found out by #39, panamax in is actual state need an URL rewriting to work properly while serving crates.

It is true that NGINX can do it efficiently but I do not think it is really needed, so here come my pull request.

The main part of the solution is to use the `{prefix}` in the `dl` URL of the `config.json`.

- [x] Change config.json
- [x] Update the builtin server