### PR TITLE
Self-use version submission

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+[source.crates-io]
+replace-with = 'tuna'
+
+[source.ustc]
+registry = "https://mirrors.ustc.edu.cn/crates.io-index"
+
+[source.tuna]
+registry = "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'panamax'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=panamax",
+                    "--package=panamax"
+                ],
+                "filter": {
+                    "name": "panamax",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "serve",
+                "/mirror"
+            ],
+            "cwd": "${workspaceFolder}"
+        }
+       
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             },
             "args": [
                 "serve",
-                "/mirror"
+                "D:/rust"
             ],
             "cwd": "${workspaceFolder}"
         }

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,13 @@ RUN cargo build --release $CARGO_BUILD_EXTRA
 FROM debian:latest
 
 COPY --from=builder /app/target/release/panamax /usr/local/bin
-RUN apt update
-RUN apt install -y libssl1.1 ca-certificates git
+
+# chagne to ustc source
+RUN sed -i "s/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list
+RUN sed -i "s/security.debian.org/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list
+RUN apt update && apt install -y apt-transport-https ca-certificates
+RUN sed -i "s/http/https/g" /etc/apt/sources.list
+RUN apt update && apt install -y libssl1.1 git
 
 ENTRYPOINT [ "/usr/local/bin/panamax" ]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM rust:latest AS builder
 
 WORKDIR /app
 
-#ADD --chown=rust:rust . /app/
 ADD . /app/
 
 ARG CARGO_BUILD_EXTRA
@@ -12,7 +11,7 @@ FROM debian:latest
 
 COPY --from=builder /app/target/release/panamax /usr/local/bin
 RUN apt update
-RUN apt install -y libssl1.1 ca-certificates
+RUN apt install -y libssl1.1 ca-certificates git
 
 ENTRYPOINT [ "/usr/local/bin/panamax" ]
 CMD ["--help"]

--- a/src/crates_index.rs
+++ b/src/crates_index.rs
@@ -154,7 +154,7 @@ pub fn rewrite_config_json(repo_path: &Path, base_url: &str) -> Result<(), Index
 
     let mut index = repo.index()?;
 
-    let crate_path = format!("{}/{}", base_url, "{crate}/{crate}-{version}.crate");
+    let crate_path = format!("{}/{}", base_url, "crates/{crate}/{crate}-{version}.crate");
 
     // Create the new config.json.
     let config_json = ConfigJson {

--- a/src/mirror.default.toml
+++ b/src/mirror.default.toml
@@ -106,6 +106,9 @@ download_dev = false
 # Perform crates synchronization. Set this to false if you only want to mirror rustup.
 sync = true
 
+# Perform crates synchronization. Set this to false if you only want to mirror crates.io-index
+sync_crates = true
+
 
 # Number of downloads that can be ran in parallel.
 download_threads = 64

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -53,6 +53,7 @@ pub struct ConfigRustup {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ConfigCrates {
     pub sync: bool,
+    pub sync_crates: bool,
     pub download_threads: usize,
     pub source: String,
     pub source_index: String,
@@ -233,11 +234,17 @@ pub async fn sync_crates(
         return;
     }
 
-    if let Err(e) = crate::crates::sync_crates_files(path, mirror, crates, user_agent).await {
-        eprintln!("Downloading crates failed: {:?}", e);
-        eprintln!("You will need to sync again to finish this download.");
-        return;
+    if crates.sync_crates {
+        if let Err(e) = crate::crates::sync_crates_files(path, mirror, crates, user_agent).await {
+            eprintln!("Downloading crates failed: {:?}", e);
+            eprintln!("You will need to sync again to finish this download.");
+            return;
+        }
+    }else{
+        eprintln!("Crates files sync is disabled, skipping...");
     }
+
+    
 
     if let Err(e) = crate::crates_index::update_crates_config(path, crates) {
         eprintln!("Updating crates.io-index config failed: {:?}", e);

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@ source ~/.bashrc</pre>
 
 cat &lt;&lt;EOT > ~/.cargo/config
 [source.panamax]
-registry = "{{ host }}/git/crates.io-index"
+registry = "{{ host }}/crates.io-index"
 [source.crates-io]
 replace-with = "panamax"
 EOT</pre>


### PR DESCRIPTION
1. Support sync the crates.io-index only.    
2. Change crates.io-index path from {host}/git/crates.io-index to {host}/crates.io-index,
3. The home page url use config value in mirror.toml.
4. Fix url write error for crates download url. it's miss "/crates/" session after {host}.
5. Add some log output.