### PR TITLE
ignore GitHub action files

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -138,6 +138,9 @@ pub async fn sync_crates_files(
             if p == Path::new("config.json") {
                 return true;
             }
+            if p.starts_with(".github/") {
+                return true;
+            }
 
             // DEV: if dev_reduced_crates is enabled, only download crates that start with z
             #[cfg(feature = "dev_reduced_crates")]
@@ -167,7 +170,12 @@ pub async fn sync_crates_files(
             // Download one crate for each of the versions in the crate file
             for line in Cursor::new(data).lines() {
                 let line = line.unwrap();
-                let c: CrateEntry = serde_json::from_str(&line).unwrap();
+                let c: CrateEntry = match serde_json::from_str(&line) {
+                    Ok(c) => c,
+                    Err(_) => {
+                        continue;
+                    }
+                };
 
                 changed_crates.push(c);
             }


### PR DESCRIPTION
When syncing the [crates.io-index](https://github.com/rust-lang/crates.io), the GitHub action file `update-dl-url.yml`is present in the Git mirror and will not be filtered out like `config.json`. It fails to be deserialized at line https://github.com/panamax-rs/panamax/blob/d3e67b0a50297023e944c9bf56ebb0e9e7b9c6bb/src/crates.rs#L170 and panamax panics:

```text
Syncing Crates repositories...
[1/3] Fetching crates.io-index...
[2/3] Syncing crates files...
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid number", line: 1, column: 2)', src/crates.rs:170:65
[2/3] Syncing crates files...
```

Now, paths that start with '.github/' will be skipped and the JSON deserialization should not stop the program if it fails.
