### PR TITLE
Adding feature to verify coherence between local index and mirror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "panamax"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "askama",
  "askama_warp",

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -35,7 +35,17 @@ pub struct CrateEntry {
     name: String,
     vers: String,
     cksum: String,
-    yanked: bool,
+    pub(crate) yanked: bool,
+}
+
+impl CrateEntry {
+    pub(crate) fn get_name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub(crate) fn get_vers(&self) -> &str {
+        self.vers.as_str()
+    }
 }
 
 /// Download one single crate file.

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -36,7 +36,7 @@ pub struct CrateEntry {
     name: String,
     vers: String,
     cksum: String,
-    pub(crate) yanked: bool,
+    yanked: bool,
 }
 
 impl CrateEntry {
@@ -46,6 +46,10 @@ impl CrateEntry {
 
     pub(crate) fn get_vers(&self) -> &str {
         self.vers.as_str()
+    }
+
+    pub(crate) fn get_yanked(&self) -> bool {
+        self.yanked
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod mirror;
 mod progress_bar;
 mod rustup;
 mod serve;
+mod verify;
 
 /// Mirror rustup and crates.io repositories, for offline Rust and cargo usage.
 #[derive(Debug, StructOpt)]
@@ -81,6 +82,14 @@ enum Panamax {
         #[structopt(long, default_value = "nightly")]
         channel: String,
     },
+
+    /// Verify coherence between local mirror and local crates.io-index.
+    #[structopt(name = "verify", alias = "check")]
+    Verify {
+        /// Mirror directory.
+        #[structopt(parse(from_os_str))]
+        path: PathBuf,
+    },
 }
 
 #[tokio::main]
@@ -99,6 +108,7 @@ async fn main() {
             key_path,
         } => mirror::serve(path, listen, port, cert_path, key_path).await,
         Panamax::ListPlatforms { source, channel } => mirror::list_platforms(source, channel).await,
+        Panamax::Verify { path } => mirror::verify(path).await,
     }
     .unwrap_or_else(|e| eprintln!("Panamax command failed! {}", e));
 }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -13,6 +13,7 @@ use crate::crates_index::rewrite_config_json;
 use crate::download::download_string;
 use crate::rustup::Channel;
 use crate::serve::TlsConfig;
+use crate::verify::{self, VerifyError};
 
 #[derive(Error, Debug)]
 pub enum MirrorError {
@@ -317,6 +318,43 @@ pub(crate) async fn list_platforms(source: String, channel: String) -> Result<()
     );
     for t in targets {
         println!("  {}", t);
+    }
+
+    Ok(())
+}
+
+/// Verify coherence between local mirror and local crates.io-index.
+pub(crate) async fn verify(path: PathBuf) -> Result<(), MirrorError> {
+    if !path.join("mirror.toml").exists() {
+        eprintln!(
+            "Mirror base not found! Run panamax init {} first.",
+            path.display()
+        );
+        return Ok(());
+    }
+    let mirror = load_mirror_toml(&path)?;
+
+    // Fail if use_new_crates_format is not true, and old format is detected.
+    // If use_new_crates_format is true and new format is detected, warn the user.
+    // If use_new_crates_format is true, ignore the format and assume it's new.
+    if let Some(crates) = &mirror.crates {
+        if crates.sync && !is_new_crates_format(&path.join("crates"))? {
+            eprintln!("Your crates directory is using the old 0.2 format, however");
+            eprintln!("Panamax 0.3+ has deprecated this format for a new one.");
+            eprintln!("Please delete crates/ from your mirror directory to continue.");
+            return Ok(());
+        }
+    }
+
+    eprintln!("{}", style("Verifying mirror state...").bold());
+
+    if let Err(e) = verify::verify_mirror(path).await {
+        match e {
+            VerifyError::MissingCrates(vec) => vec.iter().for_each(|c| {
+                eprintln!("Missing crate: {} - version {}", c.get_name(), c.get_vers());
+            }),
+            VerifyError::GitError(e) => eprintln!("Git Error: {e}"),
+        }
     }
 
     Ok(())

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{BufRead, Cursor},
     path::Path,
+    time::Duration,
 };
 
 use console::style;
@@ -72,11 +73,12 @@ pub(crate) async fn verify_mirror(path: std::path::PathBuf) -> Result<(), Verify
         .with_style(
             ProgressStyle::default_bar()
                 .template("{prefix} {wide_bar} {spinner} [{elapsed_precise}]")
-                .progress_chars("  ")
-                .on_finish(ProgressFinish::AndLeave),
+                .expect("Something went wrong with the template.")
+                .progress_chars("  "),
         )
-        .with_prefix(prefix);
-    pb.enable_steady_tick(10);
+        .with_prefix(prefix)
+        .with_finish(ProgressFinish::AndLeave);
+    pb.enable_steady_tick(Duration::from_millis(10));
 
     diff.foreach(
         &mut |delta, _| {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,138 @@
+use std::{
+    io::{BufRead, Cursor},
+    path::Path,
+};
+
+use console::style;
+use git2::Repository;
+use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
+use thiserror::Error;
+
+use crate::{
+    crates::{get_crate_path, CrateEntry},
+    progress_bar::padded_prefix_message,
+};
+
+///
+/// This variable is here to avoid to have false positive regarding crates.io [issue#1593](https://github.com/rust-lang/crates.io/issues/1593).
+///
+static CRATES_403: [(&str, &str); 22] = [
+    ("glib-2-0-sys", "0.0.1"),
+    ("glib-2-0-sys", "0.0.2"),
+    ("glib-2-0-sys", "0.0.3"),
+    ("glib-2-0-sys", "0.0.4"),
+    ("glib-2-0-sys", "0.0.5"),
+    ("glib-2-0-sys", "0.0.6"),
+    ("glib-2-0-sys", "0.0.7"),
+    ("glib-2-0-sys", "0.0.8"),
+    ("glib-2-0-sys", "0.1.0"),
+    ("glib-2-0-sys", "0.1.1"),
+    ("glib-2-0-sys", "0.1.2"),
+    ("glib-2-0-sys", "0.2.0"),
+    ("gobject-2-0-sys", "0.0.2"),
+    ("gobject-2-0-sys", "0.0.3"),
+    ("gobject-2-0-sys", "0.0.2"),
+    ("gobject-2-0-sys", "0.0.4"),
+    ("gobject-2-0-sys", "0.0.5"),
+    ("gobject-2-0-sys", "0.0.6"),
+    ("gobject-2-0-sys", "0.0.7"),
+    ("gobject-2-0-sys", "0.0.8"),
+    ("gobject-2-0-sys", "0.1.0"),
+    ("gobject-2-0-sys", "0.2.0"),
+];
+
+#[derive(Error, Debug)]
+pub enum VerifyError {
+    #[error("Git error: {0}")]
+    GitError(#[from] git2::Error),
+
+    #[error("Missing crate(s): {0:?}")]
+    MissingCrates(Vec<CrateEntry>),
+}
+
+pub(crate) async fn verify_mirror(path: std::path::PathBuf) -> Result<(), VerifyError> {
+    // Checking existence of local index
+    let repo_path = path.join("crates.io-index");
+
+    if !repo_path.join(".git").exists() {
+        eprintln!("No index repository found in {}.", repo_path.display())
+    }
+
+    let prefix = padded_prefix_message(1, 1, "Comparing crates.io and mirror coherence");
+
+    // Getting diff tree from local crates.io repository.
+    let repo = Repository::open(repo_path)?;
+    let master = repo.find_reference("refs/heads/master")?;
+    let master_tree = master.peel_to_tree()?;
+    let diff = repo.diff_tree_to_tree(None, Some(&master_tree), None)?;
+
+    let mut missing_crates = Vec::new();
+
+    let pb = ProgressBar::new_spinner()
+        .with_style(
+            ProgressStyle::default_bar()
+                .template("{prefix} {wide_bar} {spinner} [{elapsed_precise}]")
+                .progress_chars("  ")
+                .on_finish(ProgressFinish::AndLeave),
+        )
+        .with_prefix(prefix);
+    pb.enable_steady_tick(10);
+
+    diff.foreach(
+        &mut |delta, _| {
+            let df = delta.new_file();
+            let p = df.path().unwrap();
+            if p == Path::new("config.json") {
+                return true;
+            }
+            if p.starts_with(".github/") {
+                return true;
+            }
+
+            let oid = df.id();
+            if oid.is_zero() {
+                return true;
+            }
+            let blob = repo.find_blob(oid).unwrap();
+            let data = blob.content();
+
+            // Iterating over each line of a JSON file from local crates.io repository
+            for line in Cursor::new(data).lines() {
+                let line = line.unwrap();
+                let crate_entry: CrateEntry = match serde_json::from_str(&line) {
+                    Ok(c) => c,
+                    Err(_) => {
+                        continue;
+                    }
+                };
+
+                // Building crates local path.
+                let file_path =
+                    get_crate_path(&path, crate_entry.get_name(), crate_entry.get_vers()).unwrap();
+
+                // Checking if crate is missing.
+                if !CRATES_403
+                    .iter()
+                    .any(|it| it.0 == crate_entry.get_name() && it.1 == crate_entry.get_vers())
+                    && !crate_entry.yanked
+                    && !file_path.exists()
+                {
+                    missing_crates.push(crate_entry);
+                }
+            }
+
+            true
+        },
+        None,
+        None,
+        None,
+    )?;
+
+    if !missing_crates.is_empty() {
+        return Err(VerifyError::MissingCrates(missing_crates));
+    }
+
+    eprintln!("{}", style("Verification successful.").bold());
+
+    Ok(())
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -17,7 +17,7 @@ use crate::{
 ///
 /// This variable is here to avoid to have false positive regarding crates.io [issue#1593](https://github.com/rust-lang/crates.io/issues/1593).
 ///
-static CRATES_403: [(&str, &str); 22] = [
+static CRATES_403: [(&str, &str); 23] = [
     ("glib-2-0-sys", "0.0.1"),
     ("glib-2-0-sys", "0.0.2"),
     ("glib-2-0-sys", "0.0.3"),
@@ -38,6 +38,7 @@ static CRATES_403: [(&str, &str); 22] = [
     ("gobject-2-0-sys", "0.0.6"),
     ("gobject-2-0-sys", "0.0.7"),
     ("gobject-2-0-sys", "0.0.8"),
+    ("gobject-2-0-sys", "0.0.9"),
     ("gobject-2-0-sys", "0.1.0"),
     ("gobject-2-0-sys", "0.2.0"),
 ];
@@ -59,7 +60,7 @@ pub(crate) async fn verify_mirror(path: std::path::PathBuf) -> Result<(), Verify
         eprintln!("No index repository found in {}.", repo_path.display())
     }
 
-    let prefix = padded_prefix_message(1, 1, "Comparing crates.io and mirror coherence");
+    let prefix = padded_prefix_message(1, 1, "Comparing local crates.io and mirror coherence");
 
     // Getting diff tree from local crates.io repository.
     let repo = Repository::open(repo_path)?;
@@ -116,7 +117,7 @@ pub(crate) async fn verify_mirror(path: std::path::PathBuf) -> Result<(), Verify
                 if !CRATES_403
                     .iter()
                     .any(|it| it.0 == crate_entry.get_name() && it.1 == crate_entry.get_vers())
-                    && !crate_entry.yanked
+                    && !crate_entry.get_yanked()
                     && !file_path.exists()
                 {
                     missing_crates.push(crate_entry);
@@ -129,6 +130,8 @@ pub(crate) async fn verify_mirror(path: std::path::PathBuf) -> Result<(), Verify
         None,
         None,
     )?;
+
+    pb.finish();
 
     if !missing_crates.is_empty() {
         return Err(VerifyError::MissingCrates(missing_crates));


### PR DESCRIPTION
Hi there! :wave: 

So here the things, a few days ago, I was using `panamax` and decided to synchronize my mirror (after maybe one month or two without doing it).
What happened is exactly what is described on [issue#55](https://github.com/panamax-rs/panamax/issues/55) (which is now closed by the author).

To sum up, I had my mirror in an inconsistent state: index was referencing a crate, but this one was not present on my mirror.
This happened right after `panamax sync /path/to/my/mirror`, although `panamax` stated the sync was a success.
As I really needed an up-to-date mirror, I deleted the mirror and ran a fresh new sync. And then it worked, my mirror was coherent with the index.

But, the problem remains.
I tried to trigger it again, but without any success.
So I decided to do add a quick feature to detect this kind of problem.

Of course do not hesitate to say what you think about my contribution (this is my first one ever :metal: ) and feel free to modify it.

Main changes:

- [x] Added an `impl` on `CrateEntry` to be able to obtain reference to crate's name and version.
- [x] Passed visibility of `CrateEntry.yanked` to `pub(crate)`
- [x] Adding a module (`verify.rs`) containing the logic.