### PR TITLE
Fix Docker Image Failing to Sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ RUN cargo build --release $CARGO_BUILD_EXTRA
 FROM debian:latest
 
 COPY --from=builder /app/target/release/panamax /usr/local/bin
-RUN apt update
-RUN apt install -y libssl1.1 ca-certificates
+
+RUN apt update \
+  && apt install -y \
+    ca-certificates \
+    git \
+    libssl1.1
 
 ENTRYPOINT [ "/usr/local/bin/panamax" ]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Alternatively, you can clone this repository and `cargo build` or `cargo run` wi
 Panamax is available as a docker image, so you can run:
 
 ```
-$ docker run -it -v /path/to/mirror/:/mirror panamaxrs/panamax init /mirror
+$ docker run --rm -it -v /path/to/mirror/:/mirror panamaxrs/panamax init /mirror
 (Modify /path/to/mirror/mirror.toml as needed)
-$ docker run -it -v /path/to/mirror/:/mirror panamaxrs/panamax sync /mirror
+$ docker run --rm -it -v /path/to/mirror/:/mirror panamaxrs/panamax sync /mirror
 (Once synced, serve the mirror)
-$ docker run -it -v /path/to/mirror/:/mirror -p8080:8080 panamaxrs/panamax serve /mirror
+$ docker run --rm -it -v /path/to/mirror/:/mirror -p8080:8080 panamaxrs/panamax serve /mirror
 ```
 
 Alternatively, you can run panamax in a bare-metal environment like below.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Panamax is a tool to mirror the Rust and crates.io repositories, for offline usa
 Panamax is itself available on crates.io, and can be installed via:
 
 ```
-$ cargo install panamax
+$ cargo install --locked panamax
 ```
 
 Alternatively, you can clone this repository and `cargo build` or `cargo run` within it.


### PR DESCRIPTION
The current panamax docker image if failing to sync most crates, because it is missing git.
This MR adds git to the dockerfile to fix this.

Resolves #51 

Also updated the readme which should resolve #61 