### PR TITLE
Adding --no_update_index option for syncing crates files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,13 @@ enum Panamax {
         /// Mirror directory.
         #[structopt(parse(from_os_str))]
         path: PathBuf,
+
+        /// Sync but do not update the index.
+        /// We have the index we want to use, and
+        /// do not want to possibly break our
+        /// environment since we aren't connect to github.
+        #[structopt(short, long)]
+        no_update_index: bool,
     },
 
     /// Rewrite the config.json within crates.io-index.
@@ -98,7 +105,7 @@ async fn main() {
     let opt = Panamax::from_args();
     match opt {
         Panamax::Init { path } => mirror::init(&path),
-        Panamax::Sync { path } => mirror::sync(&path).await,
+        Panamax::Sync { path, no_update_index } => mirror::sync(&path, no_update_index).await,
         Panamax::Rewrite { path, base_url } => mirror::rewrite(&path, base_url),
         Panamax::Serve {
             path,


### PR DESCRIPTION
* Adding --no_update_index option for syncing crates files without updating index
 - Updating src/main.rs to include new option for Sync, --no_update_index, which is a bool
 - Updating src/mirror.rs to include capability to pass down no_update_index bool to sync_crates() method
 - Performing a check in sync_crates(), if !no_update_index, then do the syncing of the crates repom and update the crates config