### PR TITLE
Use cargo vendor for mirroring selected crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "tokio-util 0.6.9",
  "toml",
  "url",
+ "walkdir",
  "warp",
 ]
 
@@ -1326,6 +1327,15 @@ name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1865,6 +1875,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,7 @@ tokio-stream = "0.1.7"
 tokio-util = { version = "0.6.8", features = ["codec"] }
 futures-util = "0.3.17"
 futures = "0.3.17"
+walkdir = "2.3.2"
 
 [features]
 default = []
-
-# For development purposes, reduce the crate download count
-# and only download crates that start with z
-dev_reduced_crates = []

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ This directory can now be copied to a USB or rsync'd somewhere else, or even use
 
 Additionally, this mirror can continually by synchronized in the future - one recommendation is to run this command in a cronjob once each night, to keep the mirror reasonably up to date.
 
+### Sync Select Dependencies
+Optionally, panamax can be told to only grab crates needed to build a singular project.
+`cargo vendor` is used to create a folder with all needed dependencies,
+then a panamax command can parse the created directory and only grab those crates and versions.
+```
+# Only grab crates needed for panamax, as an example
+$ cargo vendor
+$ panamax sync my-mirror vendor
+```
+
 ## Server
 
 Panamax provides a warp-based HTTP(S) server that can handle serving a Rust mirror fast and at scale. This is the recommended way to serve the mirror.

--- a/src/download.rs
+++ b/src/download.rs
@@ -234,7 +234,7 @@ pub async fn download_with_sha256_file(
     force_download: bool,
     user_agent: &HeaderValue,
 ) -> Result<(), DownloadError> {
-    let sha256_url = format!("{}.sha256", url);
+    let sha256_url = format!("{url}.sha256");
     let sha256_data = download_string(&sha256_url, user_agent).await?;
 
     let sha256_hash = &sha256_data[..64];

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,9 @@ enum Panamax {
         /// Mirror directory.
         #[clap(parse(from_os_str))]
         path: PathBuf,
+        /// cargo-vendor directory.
+        #[clap(parse(from_os_str))]
+        vendor_path: Option<PathBuf>,
     },
 
     /// Rewrite the config.json within crates.io-index.
@@ -95,7 +98,7 @@ async fn main() {
     let opt = Panamax::parse();
     match opt {
         Panamax::Init { path } => mirror::init(&path),
-        Panamax::Sync { path } => mirror::sync(&path).await,
+        Panamax::Sync { path, vendor_path } => mirror::sync(&path, vendor_path).await,
         Panamax::Rewrite { path, base_url } => mirror::rewrite(&path, base_url),
         Panamax::Serve {
             path,

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -117,7 +117,7 @@ pub fn default_user_agent() -> String {
     format!("Panamax/{}", env!("CARGO_PKG_VERSION"))
 }
 
-pub async fn sync(path: &Path) -> Result<(), MirrorError> {
+pub async fn sync(path: &Path, vendor_path: Option<PathBuf>) -> Result<(), MirrorError> {
     if !path.join("mirror.toml").exists() {
         eprintln!(
             "Mirror base not found! Run panamax init {} first.",
@@ -174,7 +174,7 @@ pub async fn sync(path: &Path) -> Result<(), MirrorError> {
 
     if let Some(crates) = mirror.crates {
         if crates.sync {
-            sync_crates(path, &mirror.mirror, &crates, &user_agent).await;
+            sync_crates(path, vendor_path, &mirror.mirror, &crates, &user_agent).await;
         } else {
             eprintln!("Crates sync is disabled, skipping...");
         }
@@ -222,6 +222,7 @@ pub fn rewrite(path: &Path, base_url: Option<String>) -> Result<(), MirrorError>
 /// Synchronize and handle the crates.io-index repository.
 pub async fn sync_crates(
     path: &Path,
+    vendor_path: Option<PathBuf>,
     mirror: &ConfigMirror,
     crates: &ConfigCrates,
     user_agent: &HeaderValue,
@@ -234,7 +235,9 @@ pub async fn sync_crates(
         return;
     }
 
-    if let Err(e) = crate::crates::sync_crates_files(path, mirror, crates, user_agent).await {
+    if let Err(e) =
+        crate::crates::sync_crates_files(path, vendor_path, mirror, crates, user_agent).await
+    {
         eprintln!("Downloading crates failed: {:?}", e);
         eprintln!("You will need to sync again to finish this download.");
         return;


### PR DESCRIPTION
Add give a path to a folder created from `cargo-vendor`, which contains a folder of
all crates that can be easily parsed while letting cargo-vendor do the
hard job of grabbing the correct depends.

The code then walks that directory looking for crate name and the version, and only downloads
those specific crates from crates.io.

See #63  


## Example usage
```shell
$ cd panamax
$ cargo vendor
$ cargo r --release -- init offline-mirror
$ cargo r --release -- sync offline-mirror vendor/
```

NOTE: Since this compares only the diff between the previous git grab of `crates.io`, before grabbing new version / new crates for the offline mirror you need to `rm -rf offline-mirror/crates.io-index/` to ensure all crates are compared every time and depends are correctly downloaded.