### PR TITLE
Add feature vendored-openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1022,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ walkdir = "2.3.2"
 
 [features]
 default = []
+vendored-openssl = ["reqwest/native-tls-vendored"]


### PR DESCRIPTION
This enables building for x86_64-unknown-linux-musl and other targets for which openssl is rough to compile on such as a macOS.
### Test:
```
cargo build --features vendored-openssl --target x86_64-unknown-linux-musl
```