### PR TITLE
Update locked cpufeatures to v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
The following error shows for `cargo install --locked panamax`

```
warning: package `cpufeatures v0.2.2` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
```