### PR TITLE
Add --ignore-rustup to init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -183,6 +183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "console"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +249,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -702,6 +718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,15 +914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +1030,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.7.1",
+ "toml_edit",
  "url",
  "walkdir",
  "warp",
@@ -1406,15 +1422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,37 +1680,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_edit"
-version = "0.19.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
+ "combine",
  "indexmap",
- "nom8",
+ "itertools",
  "serde",
- "serde_spanned",
- "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 reqwest = { version = "0.11.4", features = ["blocking"] }
 indicatif = "0.17"
 clap = { version = "4.1", features = ["derive"] }
-toml = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 console = "0.15"
 log = "0.4"
@@ -35,6 +34,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = "0.3"
 futures = "0.3"
 walkdir = "2.3"
+toml_edit = {version = "0.14.0", features = ["easy"] }
 
 [features]
 default = []

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -21,12 +21,16 @@ use thiserror::Error;
 pub enum SyncError {
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
+
     #[error("Download error: {0}")]
     Download(#[from] DownloadError),
+
     #[error("JSON serialization error: {0}")]
     SerializeError(#[from] serde_json::Error),
+
     #[error("Git error: {0}")]
     GitError(#[from] git2::Error),
+
     #[error("Index syncing error: {0}")]
     IndexSync(#[from] IndexSyncError),
 }
@@ -111,8 +115,8 @@ pub async fn sync_crates_files(
             let path = entry.as_ref().unwrap().path();
             if path.file_name() == Some(OsStr::new("Cargo.toml")) {
                 let s = fs::read_to_string(entry.unwrap().path()).unwrap();
-                let crate_toml = s.parse::<toml::Value>().unwrap();
-                if let toml::Value::Table(crate_f) = crate_toml {
+                let crate_toml = s.parse::<toml_edit::easy::Value>().unwrap();
+                if let toml_edit::easy::Value::Table(crate_f) = crate_toml {
                     let name = crate_f["package"]["name"].to_string().replace('\"', "");
                     let version = crate_f["package"]["version"].to_string().replace('\"', "");
                     vendors.push((name, version));

--- a/src/crates_index.rs
+++ b/src/crates_index.rs
@@ -15,10 +15,13 @@ use crate::progress_bar::padded_prefix_message;
 pub enum IndexSyncError {
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
+
     #[error("JSON serialization error: {0}")]
     SerializeError(#[from] serde_json::Error),
+
     #[error("Git error: {0}")]
     GitError(#[from] git2::Error),
+
     #[error("Number conversion error: {0}")]
     IntegerConversionError(#[from] TryFromIntError),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@ enum Panamax {
     Init {
         #[arg(value_parser)]
         path: PathBuf,
+
+        /// set [rustup] sync = false
+        #[clap(long)]
+        ignore_rustup: bool,
     },
 
     /// Update an existing mirror directory.
@@ -24,6 +28,7 @@ enum Panamax {
         /// Mirror directory.
         #[arg(value_parser)]
         path: PathBuf,
+
         /// cargo-vendor directory.
         #[arg(value_parser)]
         vendor_path: Option<PathBuf>,
@@ -79,7 +84,8 @@ enum Panamax {
     ListPlatforms {
         #[arg(long, default_value = "https://static.rust-lang.org")]
         source: String,
-        #[arg(long, default_value = "nightly")]
+
+        #[clap(long, default_value = "nightly")]
         channel: String,
     },
 
@@ -108,7 +114,10 @@ async fn main() {
     env_logger::init();
     let opt = Panamax::parse();
     match opt {
-        Panamax::Init { path } => mirror::init(&path),
+        Panamax::Init {
+            path,
+            ignore_rustup,
+        } => mirror::init(&path, ignore_rustup),
         Panamax::Sync { path, vendor_path } => mirror::sync(&path, vendor_path).await,
         Panamax::Rewrite { path, base_url } => mirror::rewrite(&path, base_url),
         Panamax::Serve {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -223,21 +223,22 @@ async fn get_rustup_platforms(path: PathBuf) -> io::Result<Vec<Platform>> {
 
     // Look at the rustup/dist directory for all rustup-init and rustup-init.exe files.
     // Also return if the rustup-init file is a .exe or not.
-    let mut rd = tokio::fs::read_dir(rustup_path).await?;
-    while let Some(entry) = rd.next_entry().await? {
-        if entry.metadata().await?.is_dir() {
-            if let Some(name) = entry.file_name().to_str() {
-                let platform_triple = name.to_string();
-                if entry.path().join("rustup-init").exists() {
-                    output.push(Platform {
-                        is_exe: false,
-                        platform_triple,
-                    });
-                } else if entry.path().join("rustup-init.exe").exists() {
-                    output.push(Platform {
-                        is_exe: true,
-                        platform_triple,
-                    });
+    if let Ok(mut rd) = tokio::fs::read_dir(rustup_path).await {
+        while let Some(entry) = rd.next_entry().await? {
+            if entry.metadata().await?.is_dir() {
+                if let Some(name) = entry.file_name().to_str() {
+                    let platform_triple = name.to_string();
+                    if entry.path().join("rustup-init").exists() {
+                        output.push(Platform {
+                            is_exe: false,
+                            platform_triple,
+                        });
+                    } else if entry.path().join("rustup-init.exe").exists() {
+                        output.push(Platform {
+                            is_exe: true,
+                            platform_triple,
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Add --ignore-rustup, which will not create rustup directories as well as edit the default mirror.toml with sync = false
* Use toml_edit instead of toml, using the easy module for all instances that don't require mutating, and using the toml_edit stuff for the only time we need mutating.