### PR TITLE
Fix filtering of Unix platforms

### DIFF
--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -137,11 +137,14 @@ pub async fn download_platform_list(
 pub async fn get_platforms(rustup: &ConfigRustup) -> Result<Platforms, MirrorError> {
     let all = download_platform_list(&rustup.source, "nightly").await?;
 
-    let unix = all
-        .iter()
-        .filter(|x| !PLATFORMS_WINDOWS.contains(&x.as_str()))
-        .map(|x| x.to_string())
-        .collect();
+    let unix = match &rustup.platforms_unix {
+        Some(p) => p.clone(),
+        None => all
+            .iter()
+            .filter(|x| !PLATFORMS_WINDOWS.contains(&x.as_str()))
+            .map(|x| x.to_string())
+            .collect(),
+    };
 
     let windows = match &rustup.platforms_windows {
         Some(p) => p.clone(),


### PR DESCRIPTION
This fixes [issue 95](https://github.com/panamax-rs/panamax/issues/95) by applying the logic through which Windows target-triples are filtered on sync to Unix based ones.