### PR TITLE
Cargo.lock support, option changes & path prefix fix

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -41,8 +41,8 @@ pub enum SyncError {
 pub struct CrateEntry {
     name: String,
     vers: String,
-    cksum: String,
-    yanked: bool,
+    cksum: Option<String>,
+    yanked: Option<bool>,
 }
 
 impl CrateEntry {
@@ -54,7 +54,7 @@ impl CrateEntry {
         self.vers.as_str()
     }
 
-    pub(crate) fn get_yanked(&self) -> bool {
+    pub(crate) fn get_yanked(&self) -> Option<bool> {
         self.yanked
     }
 }
@@ -90,7 +90,7 @@ pub async fn sync_one_crate_entry(
         client,
         &url[..],
         &file_path,
-        Some(&crate_entry.cksum),
+        crate_entry.cksum.as_deref(),
         retries,
         false,
         user_agent,
@@ -103,12 +103,18 @@ pub async fn sync_one_crate_entry(
 pub async fn sync_crates_files(
     path: &Path,
     vendor_path: Option<PathBuf>,
+    cargo_lock_filepath: Option<PathBuf>,
     mirror: &ConfigMirror,
     crates: &ConfigCrates,
     user_agent: &HeaderValue,
 ) -> Result<(), SyncError> {
+    let is_crate_whitelist_only = vendor_path.is_some() || cargo_lock_filepath.is_some();
+
     // if a vendor_path, parse the filepath for Cargo.toml files for each crate, filling vendors
-    let vendors = vendor_path_to_vendors(vendor_path.as_ref());
+    let mut mirror_entries = vec![];
+    vendor_path_to_mirror_entries(&mut mirror_entries, vendor_path.as_ref());
+    // gather crates from Cargo.lock if supplied
+    cargo_lock_to_mirror_entries(&mut mirror_entries, cargo_lock_filepath.as_ref());
 
     let prefix = padded_prefix_message(2, 3, "Syncing crates files");
 
@@ -191,10 +197,10 @@ pub async fn sync_crates_files(
                 let c = match serde_json::from_str::<CrateEntry>(&line) {
                     Ok(c) => {
                         // if vendor_path, check for matching crate name/version
-                        if vendor_path.is_some() {
-                            if vendors
+                        if is_crate_whitelist_only {
+                            if mirror_entries
                                 .iter()
-                                .any(|a| a == &(c.name.clone(), c.vers.clone()))
+                                .any(|a| a.name == c.name && a.vers == c.vers)
                             {
                                 c
                             } else {
@@ -235,6 +241,13 @@ pub async fn sync_crates_files(
     pb.enable_steady_tick(Duration::from_millis(10));
 
     let client = Client::new();
+
+    // Dirty hack:
+    // Since we can't rely on diff tree because these crates are manually set
+    // we force them to always update.
+    if is_crate_whitelist_only {
+        changed_crates.append(&mut mirror_entries);
+    }
 
     let tasks = futures::stream::iter(changed_crates.into_iter())
         .map(|c| {
@@ -363,8 +376,10 @@ pub fn get_crate_path(
     )
 }
 
-pub(crate) fn vendor_path_to_vendors(vendor_path: Option<&PathBuf>) -> Vec<(String, String)> {
-    let mut vendors = vec![];
+pub(crate) fn vendor_path_to_mirror_entries(
+    mirror_entries: &mut Vec<CrateEntry>,
+    vendor_path: Option<&PathBuf>,
+) {
     if let Some(vendor_path) = &vendor_path {
         use walkdir::WalkDir;
         for entry in WalkDir::new(vendor_path.as_path())
@@ -378,11 +393,56 @@ pub(crate) fn vendor_path_to_vendors(vendor_path: Option<&PathBuf>) -> Vec<(Stri
                 if let toml_edit::easy::Value::Table(crate_f) = crate_toml {
                     let name = crate_f["package"]["name"].to_string().replace('\"', "");
                     let version = crate_f["package"]["version"].to_string().replace('\"', "");
-                    vendors.push((name, version));
+                    mirror_entries.push(CrateEntry {
+                        name,
+                        vers: version,
+                        cksum: None,
+                        yanked: None,
+                    });
                 }
             }
         }
     }
+}
 
-    vendors
+pub(crate) fn cargo_lock_to_mirror_entries(
+    mirror_entries: &mut Vec<CrateEntry>,
+    cargo_lock_filepath: Option<&PathBuf>,
+) {
+    if let Some(cargo_lock_filepath) = &cargo_lock_filepath {
+        if cargo_lock_filepath.is_file() {
+            let s = fs::read_to_string(cargo_lock_filepath).unwrap();
+            let cargo_lock = s.parse::<toml_edit::easy::Value>().unwrap();
+            if let toml_edit::easy::Value::Table(global) = cargo_lock {
+                let packages_array = &global["package"];
+
+                if let toml_edit::easy::Value::Array(packages) = packages_array {
+                    packages.iter().for_each(|package| {
+                        if let toml_edit::easy::Value::Table(package) = package {
+                            // filter out non crates-io crates
+                            if let Some(source) = package.get("source") {
+                                let source = source.to_string().replace('\"', "");
+                                if source.contains(
+                                    "registry+https://github.com/rust-lang/crates.io-index",
+                                ) {
+                                    let name = package["name"].to_string().replace('\"', "");
+                                    let version = package["version"].to_string().replace('\"', "");
+                                    let checksum =
+                                        package["checksum"].to_string().replace('\"', "");
+                                    mirror_entries.push(CrateEntry {
+                                        name,
+                                        vers: version,
+                                        cksum: Some(checksum),
+                                        yanked: None,
+                                    });
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        } else {
+            eprintln!("{:?} is not a Cargo.lock!", cargo_lock_filepath);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,15 @@ enum Panamax {
         path: PathBuf,
 
         /// cargo-vendor directory.
-        #[arg(value_parser)]
+        #[arg(long)]
         vendor_path: Option<PathBuf>,
+
+        /// cargo-lock file.
+        #[arg(long = "cargo-lock")]
+        cargo_lock_filepath: Option<PathBuf>,
+
+        #[arg(long)]
+        skip_rustup: bool,
     },
 
     /// Rewrite the config.json within crates.io-index.
@@ -110,6 +117,10 @@ enum Panamax {
         /// cargo-vendor directory.
         #[arg(value_parser)]
         vendor_path: Option<PathBuf>,
+
+        /// cargo-lock file.
+        #[arg(long = "cargo-lock")]
+        cargo_lock_filepath: Option<PathBuf>,
     },
 }
 
@@ -122,7 +133,12 @@ async fn main() {
             path,
             ignore_rustup,
         } => mirror::init(&path, ignore_rustup),
-        Panamax::Sync { path, vendor_path } => mirror::sync(&path, vendor_path).await,
+        Panamax::Sync {
+            path,
+            vendor_path,
+            cargo_lock_filepath,
+            skip_rustup,
+        } => mirror::sync(&path, vendor_path, cargo_lock_filepath, skip_rustup).await,
         Panamax::Rewrite { path, base_url } => mirror::rewrite(&path, base_url),
         Panamax::Serve {
             path,
@@ -137,7 +153,8 @@ async fn main() {
             dry_run,
             assume_yes,
             vendor_path,
-        } => mirror::verify(path, dry_run, assume_yes, vendor_path).await,
+            cargo_lock_filepath,
+        } => mirror::verify(path, dry_run, assume_yes, vendor_path, cargo_lock_filepath).await,
     }
     .unwrap_or_else(|e| eprintln!("Panamax command failed! {e}"));
 }


### PR DESCRIPTION
As an alternative and compliment to vendoring I've implented support for `Cargo.lock` crate downloading. https://github.com/panamax-rs/panamax/pull/71

This commit includes several changes:
- Cargo.lock crate download support with `--cargo-lock`
- ~~Fix for crates path prefixes due to crates starting with uppercase (i.e. "Inflector" crate caused index directories to be created with upper case as in `In/fl/...`, while cargo tried to download from `in/fl/...` resulting in 404.~~ (reverted for now)
- Option to skip rustup update with `--skip-rustup`
- Vendor path is now a long option instead with `--vendor_path`

It is also no longer needed to clear cargo index for vendor and Cargo.lock crate downloads. They are forced to always download for now.

# Example usage
```bash
# To skip rustup step which might take a long time
cargo run sync --skip-rustup ./mirror

# Download crates listed in Cargo.lock
cargo run sync --cargo-lock ./Cargo.lock ./mirror

# Sync with vendor
cargo run  sync --vendor_path vendor
```