### PR TITLE
Update Dockefile to libssl3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update \
   && apt install -y \
     ca-certificates \
     git \
-    libssl1.1 \
+    libssl3 \
   && git config --global --add safe.directory '*'
 
 ENTRYPOINT [ "/usr/local/bin/panamax" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ADD . /app/
 
 ARG CARGO_BUILD_EXTRA
-RUN cargo build --release $CARGO_BUILD_EXTRA
+RUN cargo build --release $CARGO_BUILD_EXTRA --features vendored-openssl
 
 FROM debian:latest
 


### PR DESCRIPTION
libssl1.1 no longer obtainable and is deprecated, update it to libssl3.
```
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package libssl1.1
E: Couldn't find any package by glob 'libssl1.1'
```