### PR TITLE
Set process exit code when sync fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -157,5 +157,8 @@ async fn main() {
             cargo_lock_filepath,
         } => mirror::verify(path, dry_run, assume_yes, vendor_path, cargo_lock_filepath).await,
     }
-    .unwrap_or_else(|e| eprintln!("Panamax command failed! {e}"));
+    .unwrap_or_else(|e| {
+        eprintln!("Panamax command failed! {e}");
+        std::process::exit(1);
+    });
 }


### PR DESCRIPTION
If using panamax in a script, this is useful to catch problems.

This commit will catch the most eggregious problems like configuration problems, but download failures in `panamax sync` will still exit successfully. I'll need to look into making more changes to allow catching this.