### PR TITLE
Download yanked crates when verifying the mirror

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -53,10 +53,6 @@ impl CrateEntry {
     pub(crate) fn get_vers(&self) -> &str {
         self.vers.as_str()
     }
-
-    pub(crate) fn get_yanked(&self) -> Option<bool> {
-        self.yanked
-    }
 }
 
 /// Download one single crate file.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -233,7 +233,6 @@ pub(crate) async fn verify_mirror(
                 if !CRATES_403
                     .iter()
                     .any(|it| it.0 == crate_entry.get_name() && it.1 == crate_entry.get_vers())
-                    && !crate_entry.get_yanked().expect("should be set")
                     && !file_path.exists()
                 {
                     missing_crates.push(crate_entry);


### PR DESCRIPTION
When verifying the mirror we shouldn't ignore yanked crates, as old crates might still need them