### PR TITLE
Clarify that cargo search is not currently supported in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ replace-with = "my-mirror"
 
 `Cargo` should now be pointing to the correct location to use the mirror.
 
-> Note, the `cargo search` command does not currently work with this mirror.
+> Note, Panamax does not currently support `cargo search` commands.
 
 ### Testing configuration
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ replace-with = "my-mirror"
 
 `Cargo` should now be pointing to the correct location to use the mirror.
 
+> Note, the `cargo search` command does not currently work with this mirror.
+
 ### Testing configuration
 
 You've now set up a Rust mirror! In order to make sure everything is set up properly, you can run a simple test:


### PR DESCRIPTION
This PR adds a single line to the README to state that `cargo search` is not supported by Panamax currently:

> Note, Panamax does not currently support `cargo search` commands.

The discussion about what steps are needed to configure `cargo`  to work with the mirror seem to indicate that once completed, `cargo` should function normally with the Panamax mirror. This is not wholly true, and no statement about the search functionality not being supported can leave users unclear if they have made an error, or if this is an unsupported feature.

Adding this clause to the README would remove this ambiguity for now.