### PR TITLE
Handle crate deletion correctly

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -21,7 +21,7 @@ use warp::{
     Filter, Rejection, Stream,
 };
 
-use crate::crates::get_crate_path;
+use crate::crates::get_crate_file_for_version;
 
 pub struct TlsConfig {
     pub cert_path: PathBuf,
@@ -256,8 +256,8 @@ async fn get_crate_file(
     name: &str,
     version: &str,
 ) -> Result<Response<Body>, Rejection> {
-    let full_path =
-        get_crate_path(&mirror_path, name, version).ok_or_else(warp::reject::not_found)?;
+    let full_path = get_crate_file_for_version(&mirror_path, name, version)
+        .ok_or_else(warp::reject::not_found)?;
 
     let file = File::open(full_path)
         .await

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -17,7 +17,7 @@ use warp::http::HeaderValue;
 
 use crate::{
     crates::{
-        cargo_lock_to_mirror_entries, get_crate_path, sync_one_crate_entry,
+        cargo_lock_to_mirror_entries, get_crate_file_for_version, sync_one_crate_entry,
         vendor_path_to_mirror_entries, CrateEntry,
     },
     download::DownloadError,
@@ -226,8 +226,12 @@ pub(crate) async fn verify_mirror(
                 }
 
                 // Building crates local path.
-                let file_path =
-                    get_crate_path(&path, crate_entry.get_name(), crate_entry.get_vers()).unwrap();
+                let file_path = get_crate_file_for_version(
+                    &path,
+                    crate_entry.get_name(),
+                    crate_entry.get_vers(),
+                )
+                .unwrap();
 
                 // Checking if crate is missing.
                 if !CRATES_403


### PR DESCRIPTION
I am not sure what the previous implementation was trying to do when crates are deleted in the upstream index, but it definitely led to some incorrect behavior.

The actual observed behavior was as follows:

1. `sync_crates_repo` fetches upstream, which contains crate deletions ([random example commit](https://github.com/rust-lang/crates.io-index/commit/bd2e07a6cf99dc9b7a83ac7ba81ac8c64cae6537))
2. `sync_crates_files` notices the deletion from the diff and stores the relative path (in this case `"ru/st/rust_code_obfuscator"`) in `removed_crates: Vec<PathBuf>`
3. `sync_crates_files` removes the file in the mirrored repo checkout at https://github.com/panamax-rs/panamax/blob/84ca2d7064f5a9931371f9eb74c4003707897a7b/src/crates.rs#L301
4. `fast_forward` calls `repo.checkout_head` which will somehow add the newly removed file as an *addition* to the index. Not sure how this happens, I am not very familiar with libgit2 
5. `rewrite_config_json` ultimately commits the re-added files alongside `config.json`, which is clearly incorrect since the intention is to only touch `config.json`.

This here is my attempt at trying to build a deletion logic that actually makes sense to me, where the crates is removed from the crate mirror instead of the index checkout. I am not familiar with panamax feature set so this could have unintended side effects. Also this is mostly untested. Perhaps a safer fix would be to just remove the deletion logic in `sync_crates_files` altogether